### PR TITLE
Добавлена возможность назначать определенные inbounds при создании пользователя и фильтровать их по точному tag, перечисленных через запятую.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,11 @@ REMNAWAVE_URL=https://example.com
 REMNAWAVE_MODE=remote
 REMNAWAVE_TOKEN=token
 
+# Опциональный параметр: указывает теги inbounds, которые будут назначаться пользователям
+# Если не указан, будут использоваться все доступные inbounds
+# Пример: INBOUND_TAGS=VLESS_TCP_REALITY,VLESS_XHTTP_REALITY
+INBOUND_TAGS=
+
 CRYPTO_PAY_ENABLED=true
 CRYPTO_PAY_TOKEN=token
 CRYPTO_PAY_URL=https://pay.crypt.bot

--- a/internal/remnawave/models.go
+++ b/internal/remnawave/models.go
@@ -44,7 +44,7 @@ type UserUpdate struct {
 	UUID                 string               `json:"uuid"`
 	Status               Status               `json:"status,omitempty"`
 	TrafficLimitBytes    int64                `json:"trafficLimitBytes"`
-	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy,omitempty"`
+	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy"`
 	ActiveUserInbounds   []string             `json:"activeUserInbounds,omitempty"`
 	ExpireAt             time.Time            `json:"expireAt,omitempty"`
 	Description          string               `json:"description,omitempty"`

--- a/internal/remnawave/models.go
+++ b/internal/remnawave/models.go
@@ -44,7 +44,7 @@ type UserUpdate struct {
 	UUID                 string               `json:"uuid"`
 	Status               Status               `json:"status,omitempty"`
 	TrafficLimitBytes    int64                `json:"trafficLimitBytes"`
-	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy"`
+	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy,omitempty"`
 	ActiveUserInbounds   []string             `json:"activeUserInbounds,omitempty"`
 	ExpireAt             time.Time            `json:"expireAt,omitempty"`
 	Description          string               `json:"description,omitempty"`

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ purchase and manage subscriptions through Telegram with multiple payment system 
 - **Subscription Notifications**: The bot automatically sends notifications to users 3 days before their subscription
   expires, helping them avoid service interruption
 - Multi-language support (Russian and English)
+- **Inbound Filtering**: Configure which specific inbound types users will have access to
 
 ## Environment Variables
 
@@ -35,6 +36,7 @@ The application requires the following environment variables to be set:
 | `REMNAWAVE_URL`          | Remnawave API URL                                                                                                    |
 | `REMNAWAVE_MODE`         | Remnawave mode (remote/local), default is remote. If local set – you can pass http://remnawave:3000 to REMNAWAVE_URL |
 | `REMNAWAVE_TOKEN`        | Authentication token for Remnawave API                                                                               |
+| `INBOUND_TAGS`           | Optional comma-separated list of inbound tags to filter which inbounds users will have access to                      |
 | `CRYPTO_PAY_ENABLED`     | Enable/disable CryptoPay payment method (true/false)                                                                 |
 | `CRYPTO_PAY_TOKEN`       | CryptoPay API token                                                                                                  |
 | `CRYPTO_PAY_URL`         | CryptoPay API URL                                                                                                    |
@@ -68,6 +70,14 @@ The bot includes a notification system that runs daily at 16:00 UTC to check for
 - Users receive a notification 3 days before their subscription expires
 - The notification includes the exact expiration date and a convenient button to renew the subscription
 - Notifications are sent in the user's preferred language
+
+## Inbound Configuration
+
+The `INBOUND_TAGS` environment variable allows you to specify which inbounds will be assigned to users:
+
+- If not set, all available inbounds will be assigned to users
+- If set, only the specified inbounds will be assigned (comma-separated list of tags)
+- Example: `INBOUND_TAGS=VLESS_TCP_REALITY,VLESS_XHTTP_REALITY`
 
 ## Plugins and Dependencies
 


### PR DESCRIPTION
Как это работает:
1. При запуске бота происходит чтение переменных окружения, включая INBOUND_TAGS
2. Когда для нового пользователя запрашиваются inbounds из Remnawave API, полученный список фильтруется
3. Только те inbounds, теги которых присутствуют в переменной INBOUND_TAGS, будут назначены пользователю
4. Если переменная INBOUND_TAGS не задана или если ни один из указанных тегов не найден, пользователю назначаются все доступные inbounds