### PR TITLE
Добавлена возможности назначать определенные inbounds при создании пользователя и реализовано ограничение показа стран для пользователей в боте

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,11 +14,6 @@ REMNAWAVE_URL=https://example.com
 REMNAWAVE_MODE=remote
 REMNAWAVE_TOKEN=token
 
-# Опциональный параметр: указывает теги inbounds, которые будут назначаться пользователям
-# Если не указан, будут использоваться все доступные inbounds
-# Пример: INBOUND_TAGS=VLESS_TCP_REALITY,VLESS_XHTTP_REALITY
-INBOUND_TAGS=
-
 CRYPTO_PAY_ENABLED=true
 CRYPTO_PAY_TOKEN=token
 CRYPTO_PAY_URL=https://pay.crypt.bot
@@ -42,3 +37,11 @@ SERVER_STATUS_URL="https://example.com/status"
 SUPPORT_URL="https://example.com/support"
 FEEDBACK_URL="https://example.com/feedback"
 CHANNEL_URL="https://t.me/examplechannel"
+
+# Список тегов inbound для назначения пользователям, разделенный запятыми
+# Например: VLESS_TCP_REALITY,VLESS_XHTTP_REALITY
+INBOUND_TAGS=
+
+# Список кодов стран для отображения пользователю, разделенный запятыми
+# Например: US,NL,DE,FR,SG
+ALLOWED_COUNTRIES=

--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,11 @@ REMNAWAVE_URL=https://example.com
 REMNAWAVE_MODE=remote
 REMNAWAVE_TOKEN=token
 
+# Опциональный параметр: указывает теги inbounds, которые будут назначаться пользователям
+# Если не указан, будут использоваться все доступные inbounds
+# Пример: INBOUND_TAGS=VLESS_TCP_REALITY,VLESS_XHTTP_REALITY
+INBOUND_TAGS=
+
 CRYPTO_PAY_ENABLED=true
 CRYPTO_PAY_TOKEN=token
 CRYPTO_PAY_URL=https://pay.crypt.bot

--- a/internal/config/cofig.go
+++ b/internal/config/cofig.go
@@ -1,12 +1,11 @@
 package config
 
 import (
+	"github.com/joho/godotenv"
 	"log/slog"
 	"os"
 	"strconv"
 	"strings"
-
-	"github.com/joho/godotenv"
 )
 
 type config struct {
@@ -37,12 +36,33 @@ type config struct {
 	adminTelegramId        int64
 	trialDays              int
 	trialTrafficLimit      int64
-	inboundTags            []string // Новое поле для хранения тегов inbounds
+	inboundTags            []string // Массив тегов для фильтрации inbounds
+	allowedCountries       []string // Добавлено: массив кодов стран для фильтрации
 }
 
 var conf config
 
-// InboundTags возвращает список тегов inbounds, которые должны быть назначены пользователю
+// Добавлена функция получения списка разрешенных стран
+func AllowedCountries() []string {
+	return conf.allowedCountries
+}
+
+// Добавлена функция проверки, разрешена ли страна
+func IsCountryAllowed(countryCode string) bool {
+	// Если список разрешенных стран пуст, разрешены все страны
+	if len(conf.allowedCountries) == 0 {
+		return true
+	}
+	
+	// Проверяем наличие кода страны в списке разрешенных
+	for _, code := range conf.allowedCountries {
+		if code == countryCode {
+			return true
+		}
+	}
+	return false
+}
+
 func InboundTags() []string {
 	return conf.inboundTags
 }
@@ -264,25 +284,38 @@ func InitConfig() {
 	}
 	conf.trafficLimit = int64(limit)
 
-	// Инициализация списка inboundTags из переменной окружения
-	inboundTagsStr := os.Getenv("INBOUND_TAGS")
-	if inboundTagsStr != "" {
-		// Разделяем теги по запятой и удаляем пробелы
-		tags := strings.Split(inboundTagsStr, ",")
-		for i := range tags {
-			tags[i] = strings.TrimSpace(tags[i])
-		}
-		conf.inboundTags = tags
-		slog.Info("Loaded inbound tags from env", "tags", conf.inboundTags)
-	} else {
-		// Если переменная не задана, будут использоваться все доступные inbounds
-		slog.Info("INBOUND_TAGS not set, all available inbounds will be used")
-		conf.inboundTags = []string{}
-	}
-
 	conf.serverStatusURL = os.Getenv("SERVER_STATUS_URL")
 	conf.supportURL = os.Getenv("SUPPORT_URL")
 	conf.feedbackURL = os.Getenv("FEEDBACK_URL")
 	conf.channelURL = os.Getenv("CHANNEL_URL")
 
+	// Добавлена обработка переменной INBOUND_TAGS
+	inboundTagsStr := os.Getenv("INBOUND_TAGS")
+	if inboundTagsStr != "" {
+		// Разбиваем строку с тегами по запятой и удаляем лишние пробелы
+		tags := strings.Split(inboundTagsStr, ",")
+		for i := range tags {
+			tags[i] = strings.TrimSpace(tags[i])
+		}
+		conf.inboundTags = tags
+		slog.Info("Loaded inbound tags", "tags", conf.inboundTags)
+	} else {
+		conf.inboundTags = []string{} // Пустой массив, если теги не указаны
+		slog.Info("No inbound tags specified, all will be used")
+	}
+
+	// Добавлена обработка переменной ALLOWED_COUNTRIES
+	allowedCountriesStr := os.Getenv("ALLOWED_COUNTRIES")
+	if allowedCountriesStr != "" {
+		// Разбиваем строку с кодами стран по запятой и удаляем лишние пробелы
+		countries := strings.Split(allowedCountriesStr, ",")
+		for i := range countries {
+			countries[i] = strings.TrimSpace(countries[i])
+		}
+		conf.allowedCountries = countries
+		slog.Info("Loaded allowed countries", "countries", conf.allowedCountries)
+	} else {
+		conf.allowedCountries = []string{} // Пустой массив, если страны не указаны
+		slog.Info("No country restrictions, all countries will be shown")
+	}
 }

--- a/internal/remnawave/client.go
+++ b/internal/remnawave/client.go
@@ -6,14 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"remnawave-tg-shop-bot/internal/config"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type Client struct {
@@ -444,7 +443,6 @@ func (r *Client) getInbounds(ctx context.Context) *[]Inbound {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, config.RemnawaveUrl()+"/api/inbounds", nil)
 	if err != nil {
 		slog.Error("Error while creating create request: %v", err)
-		return nil
 	}
 	httpReq.Header.Set("Accept", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+r.token)
@@ -452,7 +450,6 @@ func (r *Client) getInbounds(ctx context.Context) *[]Inbound {
 	resp, err := r.httpClient.Do(httpReq)
 	if err != nil {
 		slog.Error("Error while making get inbounds request: %v", err)
-		return nil
 	}
 	defer resp.Body.Close()
 
@@ -467,34 +464,38 @@ func (r *Client) getInbounds(ctx context.Context) *[]Inbound {
 		return nil
 	}
 
-	// Если нет специфичных тегов для фильтрации, возвращаем все inbounds
-	configuredTags := config.InboundTags()
-	if len(configuredTags) == 0 {
+	configTags := config.InboundTags()
+	
+	// Если теги не указаны в конфигурации, возвращаем все инбаунды
+	if len(configTags) == 0 {
+		slog.Info("No inbound tags filter set, using all inbounds")
 		return &wrapper.Response
 	}
 
-	// Фильтруем inbounds по тегам из конфигурации
-	var filteredInbounds []Inbound
-	tagsMap := make(map[string]struct{})
-
-	// Создаем карту для быстрого поиска
-	for _, tag := range configuredTags {
-		tagsMap[tag] = struct{}{}
+	// Создаем мапу тегов для быстрого поиска
+	tagsMap := make(map[string]bool)
+	for _, tag := range configTags {
+		tagsMap[tag] = true
 	}
 
-	// Фильтрация входящих соединений по тегам
+	// Фильтруем инбаунды по тегам
+	filteredInbounds := []Inbound{}
 	for _, inbound := range wrapper.Response {
-		if _, exists := tagsMap[inbound.Tag]; exists {
+		if tagsMap[inbound.Tag] {
 			filteredInbounds = append(filteredInbounds, inbound)
-			slog.Debug("Including inbound", "tag", inbound.Tag, "uuid", inbound.UUID)
 		}
 	}
 
 	if len(filteredInbounds) == 0 {
-		slog.Warn("No matching inbounds found for configured tags", "configuredTags", configuredTags)
-		return &wrapper.Response // Возвращаем все, если ни один не совпал
+		slog.Warn("No inbounds match the configured tags, falling back to all inbounds", 
+			"configuredTags", configTags)
+		return &wrapper.Response
 	}
 
-	slog.Info("Filtered inbounds", "total", len(wrapper.Response), "filtered", len(filteredInbounds))
+	slog.Info("Filtered inbounds by tags", 
+		"totalInbounds", len(wrapper.Response), 
+		"filteredInbounds", len(filteredInbounds),
+		"usedTags", configTags)
+	
 	return &filteredInbounds
 }

--- a/internal/remnawave/models.go
+++ b/internal/remnawave/models.go
@@ -44,7 +44,7 @@ type UserUpdate struct {
 	UUID                 string               `json:"uuid"`
 	Status               Status               `json:"status,omitempty"`
 	TrafficLimitBytes    int64                `json:"trafficLimitBytes"`
-	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy,omitempty"`
+	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy"`
 	ActiveUserInbounds   []string             `json:"activeUserInbounds,omitempty"`
 	ExpireAt             time.Time            `json:"expireAt,omitempty"`
 	Description          string               `json:"description,omitempty"`

--- a/internal/remnawave/models.go
+++ b/internal/remnawave/models.go
@@ -44,7 +44,7 @@ type UserUpdate struct {
 	UUID                 string               `json:"uuid"`
 	Status               Status               `json:"status,omitempty"`
 	TrafficLimitBytes    int64                `json:"trafficLimitBytes"`
-	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy"`
+	TrafficLimitStrategy TrafficLimitStrategy `json:"trafficLimitStrategy,omitempty"`
 	ActiveUserInbounds   []string             `json:"activeUserInbounds,omitempty"`
 	ExpireAt             time.Time            `json:"expireAt,omitempty"`
 	Description          string               `json:"description,omitempty"`

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ purchase and manage subscriptions through Telegram with multiple payment system 
 - **Subscription Notifications**: The bot automatically sends notifications to users 3 days before their subscription
   expires, helping them avoid service interruption
 - Multi-language support (Russian and English)
+- **Inbound Filtering**: Configure which specific inbound types users will have access to
 
 ## Environment Variables
 
@@ -35,6 +36,7 @@ The application requires the following environment variables to be set:
 | `REMNAWAVE_URL`          | Remnawave API URL                                                                                                    |
 | `REMNAWAVE_MODE`         | Remnawave mode (remote/local), default is remote. If local set – you can pass http://remnawave:3000 to REMNAWAVE_URL |
 | `REMNAWAVE_TOKEN`        | Authentication token for Remnawave API                                                                               |
+| `INBOUND_TAGS`           | Optional comma-separated list of inbound tags to filter which inbounds users will have access to                      |
 | `CRYPTO_PAY_ENABLED`     | Enable/disable CryptoPay payment method (true/false)                                                                 |
 | `CRYPTO_PAY_TOKEN`       | CryptoPay API token                                                                                                  |
 | `CRYPTO_PAY_URL`         | CryptoPay API URL                                                                                                    |
@@ -68,6 +70,14 @@ The bot includes a notification system that runs daily at 16:00 UTC to check for
 - Users receive a notification 3 days before their subscription expires
 - The notification includes the exact expiration date and a convenient button to renew the subscription
 - Notifications are sent in the user's preferred language
+
+## Inbound Configuration
+
+The `INBOUND_TAGS` environment variable allows you to specify which inbounds will be assigned to users:
+
+- If not set, all available inbounds will be assigned to users
+- If set, only the specified inbounds will be assigned (comma-separated list of tags)
+- Example: `INBOUND_TAGS=VLESS_TCP_REALITY,VLESS_XHTTP_REALITY`
 
 ## Plugins and Dependencies
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,8 @@ purchase and manage subscriptions through Telegram with multiple payment system 
 - **Subscription Notifications**: The bot automatically sends notifications to users 3 days before their subscription
   expires, helping them avoid service interruption
 - Multi-language support (Russian and English)
-- **Inbound Filtering**: Configure which specific inbound types users will have access to
+- **Selective Inbound Assignment**: Configure specific inbounds to assign to users via tag filtering
+- **Country Filtering**: Configure which countries are displayed to users in the bot interface
 
 ## Environment Variables
 
@@ -36,7 +37,6 @@ The application requires the following environment variables to be set:
 | `REMNAWAVE_URL`          | Remnawave API URL                                                                                                    |
 | `REMNAWAVE_MODE`         | Remnawave mode (remote/local), default is remote. If local set – you can pass http://remnawave:3000 to REMNAWAVE_URL |
 | `REMNAWAVE_TOKEN`        | Authentication token for Remnawave API                                                                               |
-| `INBOUND_TAGS`           | Optional comma-separated list of inbound tags to filter which inbounds users will have access to                      |
 | `CRYPTO_PAY_ENABLED`     | Enable/disable CryptoPay payment method (true/false)                                                                 |
 | `CRYPTO_PAY_TOKEN`       | CryptoPay API token                                                                                                  |
 | `CRYPTO_PAY_URL`         | CryptoPay API URL                                                                                                    |
@@ -54,6 +54,8 @@ The application requires the following environment variables to be set:
 | `ADMIN_TELEGRAM_ID`      | Admin telegram id                                                                                                    |
 | `TRIAL_TRAFFIC_LIMIT`    | Maximum allowed traffic in gb for trial subscriptions                                                                |     
 | `TRIAL_DAYS`             | Number of days for trial subscriptions                                                                               |
+| `INBOUND_TAGS`           | Comma-separated list of inbound tags to assign to users (e.g., "VLESS_TCP_REALITY,VLESS_XHTTP_REALITY")              |
+| `ALLOWED_COUNTRIES`      | Comma-separated list of country codes to show to users (e.g., "US,NL,DE,FR,SG")                                      |
 
 ## User Interface
 
@@ -73,11 +75,22 @@ The bot includes a notification system that runs daily at 16:00 UTC to check for
 
 ## Inbound Configuration
 
-The `INBOUND_TAGS` environment variable allows you to specify which inbounds will be assigned to users:
+The bot supports selective inbound assignment to users:
 
-- If not set, all available inbounds will be assigned to users
-- If set, only the specified inbounds will be assigned (comma-separated list of tags)
-- Example: `INBOUND_TAGS=VLESS_TCP_REALITY,VLESS_XHTTP_REALITY`
+- Configure specific inbound tags in the `INBOUND_TAGS` environment variable (comma-separated)
+- If specified, only inbounds with matching tags will be assigned to new users
+- If no inbounds match the specified tags or the variable is empty, all available inbounds will be assigned
+- This feature allows fine-grained control over which connection methods are available to users
+
+## Country Configuration
+
+The bot supports filtering which countries are displayed to users:
+
+- Configure specific country codes in the `ALLOWED_COUNTRIES` environment variable (comma-separated)
+- If specified, only countries with matching codes will be shown to users
+- If no countries match the specified codes or the variable is empty, all available countries will be shown
+- This feature allows you to limit which VPN locations are displayed to users
+- Country codes should be specified in ISO standard format (e.g., US, NL, DE, FR, SG)
 
 ## Plugins and Dependencies
 


### PR DESCRIPTION
**Как это работает фильтрация inbounds по тегам:**
1. В файле .env указывается переменная INBOUND_TAGS со списком тегов через запятую (например, VLESS_TCP_REALITY,VLESS_XHTTP_REALITY)
2. При старте приложения эти теги загружаются в конфигурацию
3. При создании нового пользователя:
- Запрашивается полный список доступных inbounds
- Осуществляется фильтрация по тегам, указанным в переменной INBOUND_TAGS
- Если список тегов пуст или ни один inbound не соответствует указанным тегам, используются все доступные inbounds
- Отфильтрованные inbounds назначаются пользователю.
**Как работает фильтрация стран:**
1. Администратор указывает коды нужных стран в переменной ALLOWED_COUNTRIES в формате через запятую (например: US,NL,DE,FR,SG)
2. При старте бота из API Remnawave получается полный список доступных серверов
3. Для каждого сервера проверяется:
- Что он активен и онлайн
- Что его код страны входит в список разрешенных стран ALLOWED_COUNTRIES
4. Пользователю показываются только страны, прошедшие фильтрацию
5. Если после фильтрации не осталось доступных стран, система автоматически покажет все активные страны